### PR TITLE
Interrupted migrations can be prevented from restarting on next run

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With Maven
 <dependency>
   <groupId>com.github.couchbaselabs</groupId>
   <artifactId>couchversion</artifactId>
-  <version>0.5.2</version>
+  <version>0.5.1</version>
 </dependency>
 ```
 With Gradle

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With Maven
 <dependency>
   <groupId>com.github.couchbaselabs</groupId>
   <artifactId>couchversion</artifactId>
-  <version>0.5.1</version>
+  <version>0.5.2</version>
 </dependency>
 ```
 With Gradle
@@ -188,7 +188,9 @@ Method annotated by @ChangeSet is taken and applied to the database. History of 
 
 `runAlways` - _[optional, default: false]_ changeset will always be executed but only the first execution event will be stored as a document
 
-`retries` - _[optional, default: 0]  If by some reason your changeSet throws an exception and you want to retry it instead if failing, you could set here the number of retries you want (Not sure if this feature is useful, let me know if you are using it). If all retries fail, an exception will be thrown an the application will fail to start.
+`restartInterrupted` - _[optional, default: true]_ changeset will be executed after an interruption, such as an application shutdown, or server a crash.
+
+`retries` - _[optional, default: 0]  If by some reason your changeSet throws an exception and you want to retry it instead of failing, you could set here the number of retries you want (Not sure if this feature is useful, let me know if you are using it). If all retries fail, an exception will be thrown an the application will fail to start.
 
 ![CouchVersion](https://raw.githubusercontent.com/deniswsrosa/liquicouch/master/misc/retriesExample.png)
 

--- a/src/main/java/com/github/couchversion/CouchVersion.java
+++ b/src/main/java/com/github/couchversion/CouchVersion.java
@@ -283,6 +283,7 @@ public class CouchVersion implements InitializingBean {
                 dao.save(changeEntry);
               }
               logger.info(changeEntry + " applied");
+
             } else if (service.isRunAlwaysChangeSet(changesetMethod)) {
               executeMethod(changesetMethod, changelogInstance, changeEntry);
               logger.info(changeEntry + " reapplied");

--- a/src/main/java/com/github/couchversion/CouchVersion.java
+++ b/src/main/java/com/github/couchversion/CouchVersion.java
@@ -6,7 +6,6 @@ import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.dao.CouchVersionDAO;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
 import com.github.couchversion.exception.CouchVersionConfigurationVersionException;
-import com.github.couchversion.exception.CouchVersionCounterException;
 import com.github.couchversion.exception.CouchVersionException;
 import com.github.couchversion.utils.ChangeService;
 import org.slf4j.Logger;
@@ -276,10 +275,14 @@ public class CouchVersion implements InitializingBean {
 
           try {
             if (dao.isNewChange(changeEntry)) {
+              if(!service.isRestartInterrupted(changesetMethod)){
+                dao.save(changeEntry);
+              }
               executeMethod(changesetMethod, changelogInstance, changeEntry);
-              dao.save(changeEntry);
+              if(service.isRestartInterrupted(changesetMethod)){
+                dao.save(changeEntry);
+              }
               logger.info(changeEntry + " applied");
-
             } else if (service.isRunAlwaysChangeSet(changesetMethod)) {
               executeMethod(changesetMethod, changelogInstance, changeEntry);
               logger.info(changeEntry + " reapplied");

--- a/src/main/java/com/github/couchversion/changeset/ChangeSet.java
+++ b/src/main/java/com/github/couchversion/changeset/ChangeSet.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Target;
 
 /**
  * Set of changes to be added to the DB. Many changesets are included in one changelog.
- *
  * @author deniswsrosa
  * @see ChangeLog
  */
@@ -15,46 +14,41 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ChangeSet {
 
-    /**
-     * Author of the changeset.
-     * Obligatory
-     *
-     * @return author
-     */
-    String author();  // must be set
+  /**
+   * Author of the changeset.
+   * Obligatory
+   * @return author
+   */
+  String author();  // must be set
 
-    /**
-     * Unique ID of the changeset.
-     * Obligatory
-     *
-     * @return unique id
-     */
-    String id();      // must be set
+  /**
+   * Unique ID of the changeset.
+   * Obligatory
+   * @return unique id
+   */
+  String id();      // must be set
 
-    /**
-     * Sequence that provide correct order for changesets. Sorted alphabetically, ascending.
-     * Obligatory.
-     *
-     * @return ordering
-     */
-    String order();   // must be set
+  /**
+   * Sequence that provide correct order for changesets. Sorted alphabetically, ascending.
+   * Obligatory.
+   * @return ordering
+   */
+  String order();   // must be set
 
-    /**
-     * Executes the change set on every couchversion's execution, even if it has been run before.
-     * Optional (default is false)
-     *
-     * @return should run always?
-     */
-    boolean runAlways() default false;
+  /**
+   * Executes the change set on every couchversion's execution, even if it has been run before.
+   * Optional (default is false)
+   * @return should run always?
+   */
+  boolean runAlways() default false;
 
-    int retries() default 0;
+  int retries() default 0;
 
-    /**
-     * Executes the change set after an interruption, such as an application shutdown, or server a crash.
-     * Optional (default is true)
-     *
-     * @return should restart after interruption?
-     */
-    boolean restartInterrupted() default true;
+  /**
+   * Executes the change set after an interruption, such as an application shutdown, or server a crash.
+   * Optional (default is true)
+   * @return should restart after interruption?
+   */
+  boolean restartInterrupted() default true;
 
 }

--- a/src/main/java/com/github/couchversion/changeset/ChangeSet.java
+++ b/src/main/java/com/github/couchversion/changeset/ChangeSet.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Set of changes to be added to the DB. Many changesets are included in one changelog.
+ *
  * @author deniswsrosa
  * @see ChangeLog
  */
@@ -14,34 +15,46 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ChangeSet {
 
-  /**
-   * Author of the changeset.
-   * Obligatory
-   * @return author
-   */
-  String author();  // must be set
+    /**
+     * Author of the changeset.
+     * Obligatory
+     *
+     * @return author
+     */
+    String author();  // must be set
 
-  /**
-   * Unique ID of the changeset.
-   * Obligatory
-   * @return unique id
-   */
-  String id();      // must be set
+    /**
+     * Unique ID of the changeset.
+     * Obligatory
+     *
+     * @return unique id
+     */
+    String id();      // must be set
 
-  /**
-   * Sequence that provide correct order for changesets. Sorted alphabetically, ascending.
-   * Obligatory.
-   * @return ordering
-   */
-  String order();   // must be set
+    /**
+     * Sequence that provide correct order for changesets. Sorted alphabetically, ascending.
+     * Obligatory.
+     *
+     * @return ordering
+     */
+    String order();   // must be set
 
-  /**
-   * Executes the change set on every couchversion's execution, even if it has been run before.
-   * Optional (default is false)
-   * @return should run always?
-   */
-  boolean runAlways() default false;
+    /**
+     * Executes the change set on every couchversion's execution, even if it has been run before.
+     * Optional (default is false)
+     *
+     * @return should run always?
+     */
+    boolean runAlways() default false;
 
-  int retries() default 0;
+    int retries() default 0;
+
+    /**
+     * Executes the change set after an interruption, such as an application shutdown, or server a crash.
+     * Optional (default is true)
+     *
+     * @return should restart after interruption?
+     */
+    boolean restartInterrupted() default true;
 
 }

--- a/src/main/java/com/github/couchversion/utils/ChangeService.java
+++ b/src/main/java/com/github/couchversion/utils/ChangeService.java
@@ -60,6 +60,15 @@ public class ChangeService {
     return filteredChangeSets;
   }
 
+  public boolean isRestartInterrupted(Method changesetMethod){
+    if (changesetMethod.isAnnotationPresent(ChangeSet.class)){
+      ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
+      return annotation.restartInterrupted();
+    } else {
+      return false;
+    }
+  }
+
   public boolean isRunAlwaysChangeSet(Method changesetMethod){
     if (changesetMethod.isAnnotationPresent(ChangeSet.class)){
       ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
@@ -72,7 +81,7 @@ public class ChangeService {
   public ChangeEntry createChangeEntry(Method changesetMethod){
     if (changesetMethod.isAnnotationPresent(ChangeSet.class)){
       ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
-  
+
       return new ChangeEntry(
           annotation.id(),
           annotation.author(),

--- a/src/test/java/com/github/couchversion/test/changelogs/CouchVersionChange2TestResource.java
+++ b/src/test/java/com/github/couchversion/test/changelogs/CouchVersionChange2TestResource.java
@@ -10,29 +10,28 @@ import com.github.couchversion.changeset.ChangeSet;
 @ChangeLog(order = "2")
 public class CouchVersionChange2TestResource {
 
-    @ChangeSet(author = "testuser", id = "Btest1", order = "1")
-    public void testChangeSet() {
-        System.out.println("invoked B1");
-    }
+  @ChangeSet(author = "testuser", id = "Btest1", order = "1")
+  public void testChangeSet(){
+    System.out.println("invoked B1");
+  }
+  @ChangeSet(author = "testuser", id = "Btest2", order = "2")
+  public void testChangeSet2(){
+    System.out.println("invoked B2");
+  }
 
-    @ChangeSet(author = "testuser", id = "Btest2", order = "2")
-    public void testChangeSet2() {
-        System.out.println("invoked B2");
-    }
+  @ChangeSet(author = "testuser", id = "Btest3", order = "3")
+  public void testChangeSet6(Bucket bucket) {
+    System.out.println("invoked B3 with bucket=" +bucket.name());
+  }
 
-    @ChangeSet(author = "testuser", id = "Btest3", order = "3")
-    public void testChangeSet6(Bucket bucket) {
-        System.out.println("invoked B3 with bucket=" + bucket.name());
-    }
+  @ChangeSet(author = "testuser", id = "Btest4", order = "4", runAlways = true)
+  public void testChangeSetWithAlways(Bucket bucket) {
+    System.out.println("invoked B4 with bucket=" + bucket.name());
+  }
 
-    @ChangeSet(author = "testuser", id = "Btest4", order = "4", runAlways = true)
-    public void testChangeSetWithAlways(Bucket bucket) {
-        System.out.println("invoked B4 with bucket=" + bucket.name());
-    }
-
-    @ChangeSet(author = "testuser", id = "Btest5", order = "5", restartInterrupted = false)
-    public void testChangeSetWithRestartInterrupted(Bucket bucket) {
-        System.out.println("invoked B5 with bucket=" + bucket.name());
-    }
+  @ChangeSet(author = "testuser", id = "Btest5", order = "5", restartInterrupted = false)
+  public void testChangeSetWithRestartInterrupted(Bucket bucket) {
+    System.out.println("invoked B5 with bucket=" + bucket.name());
+  }
 
 }

--- a/src/test/java/com/github/couchversion/test/changelogs/CouchVersionChange2TestResource.java
+++ b/src/test/java/com/github/couchversion/test/changelogs/CouchVersionChange2TestResource.java
@@ -10,18 +10,29 @@ import com.github.couchversion.changeset.ChangeSet;
 @ChangeLog(order = "2")
 public class CouchVersionChange2TestResource {
 
-  @ChangeSet(author = "testuser", id = "Btest1", order = "1")
-  public void testChangeSet(){
-    System.out.println("invoked B1");
-  }
-  @ChangeSet(author = "testuser", id = "Btest2", order = "2")
-  public void testChangeSet2(){
-    System.out.println("invoked B2");
-  }
+    @ChangeSet(author = "testuser", id = "Btest1", order = "1")
+    public void testChangeSet() {
+        System.out.println("invoked B1");
+    }
 
-  @ChangeSet(author = "testuser", id = "Btest3", order = "3")
-  public void testChangeSet6(Bucket bucket) {
-    System.out.println("invoked B3 with bucket=" +bucket.name());
-  }
+    @ChangeSet(author = "testuser", id = "Btest2", order = "2")
+    public void testChangeSet2() {
+        System.out.println("invoked B2");
+    }
+
+    @ChangeSet(author = "testuser", id = "Btest3", order = "3")
+    public void testChangeSet6(Bucket bucket) {
+        System.out.println("invoked B3 with bucket=" + bucket.name());
+    }
+
+    @ChangeSet(author = "testuser", id = "Btest4", order = "4", runAlways = true)
+    public void testChangeSetWithAlways(Bucket bucket) {
+        System.out.println("invoked B4 with bucket=" + bucket.name());
+    }
+
+    @ChangeSet(author = "testuser", id = "Btest5", order = "5", restartInterrupted = false)
+    public void testChangeSetWithRestartInterrupted(Bucket bucket) {
+        System.out.println("invoked B5 with bucket=" + bucket.name());
+    }
 
 }

--- a/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
@@ -2,7 +2,9 @@ package com.github.couchversion.utils;
 
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
-import com.github.couchversion.test.changelogs.*;
+import com.github.couchversion.test.changelogs.CouchVersionChange2TestResource;
+import com.github.couchversion.test.changelogs.CouchVersionTestResource;
+
 import junit.framework.Assert;
 import org.junit.Test;
 
@@ -51,7 +53,7 @@ public class ChangeServiceTest {
     List<Method> foundMethods = service.fetchChangeSets(CouchVersionChange2TestResource.class);
 
     // then
-    assertTrue(foundMethods != null && foundMethods.size() == 3);
+    assertTrue(foundMethods != null && foundMethods.size() == 5);
   }
 
 
@@ -69,6 +71,24 @@ public class ChangeServiceTest {
         assertTrue(service.isRunAlwaysChangeSet(foundMethod));
       } else {
         assertFalse(service.isRunAlwaysChangeSet(foundMethod));
+      }
+    }
+  }
+
+  @Test
+  public void shouldFindIsRestart() throws CouchVersionChangeSetVersionException {
+    // given
+    String scanPackage = CouchVersionTestResource.class.getPackage().getName();
+    ChangeService service = new ChangeService(scanPackage);
+
+    // when
+    List<Method> foundMethods = service.fetchChangeSets(CouchVersionChange2TestResource.class);
+    // then
+    for (Method foundMethod : foundMethods) {
+      if (foundMethod.getName().equals("testChangeSetWithRestartInterrupted")){
+        assertFalse(service.isRestartInterrupted(foundMethod));
+      } else {
+        assertTrue(service.isRestartInterrupted(foundMethod));
       }
     }
   }

--- a/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
@@ -2,9 +2,7 @@ package com.github.couchversion.utils;
 
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
-import com.github.couchversion.test.changelogs.CouchVersionChange2TestResource;
-import com.github.couchversion.test.changelogs.CouchVersionTestResource;
-
+import com.github.couchversion.test.changelogs.*;
 import junit.framework.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Hi @deniswsrosa - have added a new variable to the ChangeSet annotation in this PR to control whether the change set should be re-applied after an application / server failure. The current behaviour in master is that it is re-applied, which does not suit our requirements. The default behaviour has not changed, but with this flag users can control whether the ChangeEntry document is written early to CB. It would be good to get this into master as 1) others may find this feature useful, and 2) it relieves me from maintaining a fork.