### PR TITLE
Upgrade to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,21 @@
 
     <!-- TEST -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
+      <artifactId>mockito-core</artifactId>
+      <version>4.8.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -111,6 +117,12 @@
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
       </plugin>
 
       <plugin>

--- a/src/test/java/com/github/couchversion/CouchVersionEnvTest.java
+++ b/src/test/java/com/github/couchversion/CouchVersionEnvTest.java
@@ -13,8 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/java/com/github/couchversion/CouchVersionEnvTest.java
+++ b/src/test/java/com/github/couchversion/CouchVersionEnvTest.java
@@ -7,16 +7,19 @@ import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.dao.CouchVersionDAO;
 import com.github.couchversion.resources.EnvironmentMock;
 import com.github.couchversion.test.changelogs.test1.EnvironmentDependentTestResource;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static org.mockito.Mockito.*;
 
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class CouchVersionEnvTest {
 
   @Mock
@@ -33,7 +36,7 @@ public class CouchVersionEnvTest {
 
   private CouchVersion runner;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     runner = new CouchVersion(cluster, bucket);
     runner.setDAO(dao);
@@ -44,7 +47,7 @@ public class CouchVersionEnvTest {
     when(dao.hasNewChanges(anyList())).thenReturn(true);
     when(dao.getLock(anyLong())).thenReturn(true);
     when(dao.isLocked()).thenReturn(false);
-    when(dao.isNewChange(anyObject())).thenReturn(true);
+    when(dao.isNewChange(any())).thenReturn(true);
     when(bucket.defaultCollection()).thenReturn(collection);
   }
 

--- a/src/test/java/com/github/couchversion/CouchVersionProfileTest.java
+++ b/src/test/java/com/github/couchversion/CouchVersionProfileTest.java
@@ -3,7 +3,6 @@ package com.github.couchversion;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
-import com.couchbase.client.java.kv.ExistsResult;
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.dao.BucketWrapper;
 import com.github.couchversion.dao.CouchVersionDAO;
@@ -17,7 +16,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/com/github/couchversion/CouchVersionProfileTest.java
+++ b/src/test/java/com/github/couchversion/CouchVersionProfileTest.java
@@ -10,11 +10,13 @@ import com.github.couchversion.resources.EnvironmentMock;
 import com.github.couchversion.test.changelogs.CouchVersionChange2TestResource;
 import com.github.couchversion.test.profiles.def.UnProfiledChangeLog;
 import com.github.couchversion.test.profiles.dev.ProfiledDevChangeLog;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static org.mockito.Mockito.*;
 
@@ -23,7 +25,8 @@ import static org.mockito.Mockito.*;
  *
  * @author deniswsrosa
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class CouchVersionProfileTest {
 
   @Mock
@@ -44,7 +47,7 @@ public class CouchVersionProfileTest {
   private CouchVersionDAO dao;
 
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     runner = new CouchVersion(cluster, bucket);
     runner.setDAO(dao);
@@ -53,7 +56,7 @@ public class CouchVersionProfileTest {
     when(dao.hasNewChanges(anyList())).thenReturn(true);
     when(dao.getLock(anyLong())).thenReturn(true);
     when(dao.isLocked()).thenReturn(false);
-    when(dao.isNewChange(anyObject())).thenReturn(true);
+    when(dao.isNewChange(any())).thenReturn(true);
 
     when(bucket.defaultCollection()).thenReturn(collection);
   }

--- a/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
@@ -3,14 +3,14 @@ package com.github.couchversion.utils;
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
 import com.github.couchversion.test.changelogs.*;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author deniswsrosa
@@ -27,7 +27,7 @@ public class ChangeServiceTest {
     // then
     assertTrue(foundClasses != null && foundClasses.size() > 0);
   }
-  
+
   @Test
   public void shouldFindChangeSetMethods() throws CouchVersionChangeSetVersionException {
     // given
@@ -36,7 +36,7 @@ public class ChangeServiceTest {
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(CouchVersionTestResource.class);
-    
+
     // then
     assertTrue(foundMethods != null && foundMethods.size() == 3);
   }
@@ -75,17 +75,17 @@ public class ChangeServiceTest {
 
   @Test
   public void shouldCreateEntry() throws CouchVersionChangeSetVersionException {
-    
+
     // given
     String scanPackage = CouchVersionTestResource.class.getPackage().getName();
     ChangeService service = new ChangeService(scanPackage);
     List<Method> foundMethods = service.fetchChangeSets(CouchVersionTestResource.class);
 
     for (Method foundMethod : foundMethods) {
-    
+
       // when
       ChangeEntry entry = service.createChangeEntry(foundMethod);
-      
+
       // then
       Assert.assertEquals("testuser", entry.getAuthor());
       Assert.assertEquals(CouchVersionTestResource.class.getName(), entry.getChangeLogClass());

--- a/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
@@ -3,15 +3,16 @@ package com.github.couchversion.utils;
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
 import com.github.couchversion.test.changelogs.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author deniswsrosa
@@ -96,11 +97,11 @@ public class ChangeServiceTest {
     }
   }
 
-  @Test(expected = CouchVersionChangeSetVersionException.class)
+  @Test
   public void shouldFailOnDuplicatedChangeSets() throws CouchVersionChangeSetVersionException {
     String scanPackage = ChangeLogWithDuplicate.class.getPackage().getName();
     ChangeService service = new ChangeService(scanPackage);
-    service.fetchChangeSets(ChangeLogWithDuplicate.class);
+    assertThrows(CouchVersionChangeSetVersionException.class, () -> service.fetchChangeSets(ChangeLogWithDuplicate.class));
   }
 
 }

--- a/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/couchversion/utils/ChangeServiceTest.java
@@ -3,13 +3,14 @@ package com.github.couchversion.utils;
 import com.github.couchversion.changeset.ChangeEntry;
 import com.github.couchversion.exception.CouchVersionChangeSetVersionException;
 import com.github.couchversion.test.changelogs.*;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -87,11 +88,11 @@ public class ChangeServiceTest {
       ChangeEntry entry = service.createChangeEntry(foundMethod);
 
       // then
-      Assert.assertEquals("testuser", entry.getAuthor());
-      Assert.assertEquals(CouchVersionTestResource.class.getName(), entry.getChangeLogClass());
-      Assert.assertNotNull(entry.getTimestamp());
-      Assert.assertNotNull(entry.getChangeId());
-      Assert.assertNotNull(entry.getChangeSetMethodName());
+      assertEquals("testuser", entry.getAuthor());
+      assertEquals(CouchVersionTestResource.class.getName(), entry.getChangeLogClass());
+      assertNotNull(entry.getTimestamp());
+      assertNotNull(entry.getChangeId());
+      assertNotNull(entry.getChangeSetMethodName());
     }
   }
 


### PR DESCRIPTION
This MR upgrades the testing stack used in the project from JUnit 4 to JUnit Jupiter and its associated ecosystem in order to make it easier for new contributors to write and maintain tests.

The MR includes the following changes:

1. pom.xml
   1. The `junit:junit:4.10` dependency was replaced with the modern `org.junit:junit-jupiter:5.9.1`
   1. The `org.mockito:mockito-all:1.9.0` dependency was replaced with the modern `org.mockito:mockito-core:4.8.0`
   1. The dependency `org.mockito:mockito-junit-jupiter:4.0.0` was added in order to supply the `MockitoExtension` (see 4.i)
   1. The plugin `org.apache.maven.plugins:maven-surefire-plugin:2.22.2` was explicitly declared in order to run JUnit Jupiter tests from `mvn:test`

2. Annotations
   1. `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test` in the simple case where no annotation arguments were used. In the case where `org.junit.Test` was used with the `expected` argument it was still replaced by `org.junit.jupiter.api.Test`, but the test's assertions had to be amended (see 3.iii)
   1. `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`
   1. JUnit Jupiter no longer uses Runners, but instead it uses Extensions. `org.junit.runner.RunWith` annotations were removed and replaced with the corresponding `org.junit.jupiter.api.extension.ExtendWith` annotations (see 4.i)

3. Assertions
   1. `org.junit.jupiter.api.Assertions` was used as a drop-in replacement for `org.junit.Assert`
   2. `org.junit.jupiter.api.Assertions` was used as a drop-in replacement for `junit.framework.Assert`
   3. `org.junit.jupiter.api.Assertions`' `assertThrows` was used instead of the `expected` argument of `org.junit.Test`. This has a side bonus of making the test slightly stricter by checking that a specific call throws the exception and eliminates a potential false-positive if the test's "setup" code throws the expected exception
   4. Assertion imports were standardized to statically import the assertion method, as per the project's de-facto code standard

4. Mockito
   1. Calls to `@RunWith(MockitoJUnitRunner.class)` were replaced with JUnit Jupiter's mechanism of `@ExtendWith(MockitoExtension.class)`
   1. Mockito 4.x is stricter than Mockito 1.x and does not allow redundant stubbing by default. In order to keep this MR
 minimal and easy to review, the tests were annotated with `@MockitoSettings(strictness = Strictness.LENIENT)`. Future patches may want to clean up the redundant stubbing and make the tests stricter (and potentially faster)
   1. `org.mockito.Mockito`'s `any` was used as a drop-in replacement for `anyObject`, that had been removed.

5. Cleanup
   1. Unused imports in test classes were removed